### PR TITLE
Rewrite this repo with Astro instead of SvelteKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # alexswensen.io
 
-This is the source code for my personal website, [alexswensen.io](https://alexswensen.io). It is built using [SvelteKit](https://kit.svelte.dev/).
-I may also change it to Astro, but I'm not sure yet. We shall see...
+This is the source code for my personal website, [alexswensen.io](https://alexswensen.io). It is built using [Astro](https://astro.build/).
 
 ## Development
 
@@ -49,9 +48,9 @@ docker compose down
 ```
 
 
-# create-svelte
+# create-astro
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
+Everything you need to build an Astro project, powered by [`create-astro`](https://astro.build/).
 
 ## Creating a project
 
@@ -59,10 +58,10 @@ If you're seeing this, you've probably already done this step. Congrats!
 
 ```bash
 # create a new project in the current directory
-pnpm create svelte@latest
+pnpm create astro@latest
 
 # create a new project in my-app
-pnpm create svelte@latest my-app
+pnpm create astro@latest my-app
 ```
 
 ## Developing
@@ -86,4 +85,4 @@ pnpm run build
 
 You can preview the production build with `pnpm run preview`.
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+> To deploy your app, you may need to install an [adapter](https://docs.astro.build/en/guides/deploy/) for your target environment.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import auto from '@astrojs/adapter-auto';
+
+export default defineConfig({
+  adapter: auto(),
+});

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "alexswensen.io-svelte",
+	"name": "alexswensen.io-astro",
 	"version": "0.0.1",
 	"private": true,
 	"engines": {
@@ -7,25 +7,24 @@
 		"pnpm": ">=8"
 	},
 	"scripts": {
-		"dev": "vite dev",
-		"build": "vite build",
-		"preview": "vite preview",
+		"dev": "astro dev",
+		"build": "astro build",
+		"preview": "astro preview",
 		"test": "vitest",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"check": "astro check",
+		"check:watch": "astro check --watch",
 		"prettier:check": "prettier --plugin-search-dir . --check .",
 		"test:e2e": "playwright test",
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+			"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
 		"playwright:ci": "playwright test",
 		"playwright:ui": "playwright test --ui"
 	},
 	"devDependencies": {
+		"@astrojs/adapter-auto": "^2.0.0",
+		"@astrojs/vite-plugin": "^2.0.0",
 		"@playwright/test": "^1.45.1",
 		"@sentry/vite-plugin": "^0.7.2",
-		"@sveltejs/adapter-auto": "^3.2.2",
-		"@sveltejs/kit": "^2.5.18",
-		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@tailwindcss/typography": "^0.5.13",
 		"@testing-library/jest-dom": "^6.4.6",
 		"@testing-library/svelte": "^4.2.3",

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -2,16 +2,15 @@ import * as SentrySvelte from '@sentry/svelte';
 // import { BrowserTracing } from '@sentry/tracing';
 import { browserTracingIntegration, replayIntegration } from '@sentry/svelte';
 import type { HandleClientError } from '@sveltejs/kit';
-import * as _publicEnvVars from '$env/static/public';
 
 const sentryEnabled =
-	_publicEnvVars.PUBLIC_SENTRY_DSN && _publicEnvVars.PUBLIC_NODE_ENV === 'production';
+	import.meta.env.PUBLIC_SENTRY_DSN && import.meta.env.PUBLIC_NODE_ENV === 'production';
 
 if (sentryEnabled) {
 	SentrySvelte.init({
-		dsn: _publicEnvVars.PUBLIC_SENTRY_DSN,
+		dsn: import.meta.env.PUBLIC_SENTRY_DSN,
 		integrations: [browserTracingIntegration(), replayIntegration()],
-		environment: _publicEnvVars.PUBLIC_NODE_ENV,
+		environment: import.meta.env.PUBLIC_NODE_ENV,
 		tracesSampleRate: 1.0,
 		replaysSessionSampleRate: 1.0, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
 		replaysOnErrorSampleRate: 1.0

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,3 @@
-import { NODE_ENV } from '$env/static/private';
-import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 import { redirectMap } from '$lib/services/redirects';
 import * as SentryNode from '@sentry/node';
 import '@sentry/tracing';
@@ -7,13 +5,13 @@ import type { HandleServerError, Handle } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { URL } from 'url';
 
-const sentryEnabled = PUBLIC_SENTRY_DSN;
+const sentryEnabled = import.meta.env.PUBLIC_SENTRY_DSN;
 
 if (sentryEnabled) {
 	SentryNode.init({
-		dsn: PUBLIC_SENTRY_DSN,
+		dsn: import.meta.env.PUBLIC_SENTRY_DSN,
 		tracesSampleRate: 1.0,
-		environment: NODE_ENV,
+		environment: import.meta.env.NODE_ENV,
 		// Add the Http integration for tracing
 		integrations: [new SentryNode.Integrations.Http()]
 	});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
-import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { PluginOption } from 'vite';
 import compileTime from 'vite-plugin-compile-time';
+import { astro } from '@astrojs/vite-plugin';
 
 // const isProduction = process.env.NODE_ENV === 'production';
 const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
@@ -27,7 +27,7 @@ if (sentryAuthToken && org && project) {
 }
 
 export default defineConfig({
-	plugins: [sveltekit(), compileTime(), ...plugins],
+	plugins: [astro(), compileTime(), ...plugins],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		globals: true,


### PR DESCRIPTION
Update the repository to use Astro instead of SvelteKit.

* **README.md**
  - Update the description to indicate the project is now built using Astro.
  - Update the development instructions to reflect Astro-specific commands.

* **package.json**
  - Replace SvelteKit dependencies with Astro dependencies.
  - Update scripts to use Astro commands.

* **src/hooks.client.ts**
  - Update environment variable access to use `import.meta.env`.

* **src/hooks.server.ts**
  - Update environment variable access to use `import.meta.env`.

* **vite.config.ts**
  - Replace SvelteKit plugin with Astro plugin.

* **astro.config.mjs**
  - Add Astro configuration file with `@astrojs/adapter-auto` adapter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AlexSwensen/alexswensen.io?shareId=2abc0c01-dead-418e-8885-06dfb197be65).