### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     timeout-minutes: 30


### PR DESCRIPTION
Potential fix for [https://github.com/AlexSwensen/alexswensen.io/security/code-scanning/1](https://github.com/AlexSwensen/alexswensen.io/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, ideally at the root level so it applies to all jobs by default. For this workflow, the minimal safe scope is:

- `contents: read`

This supports `actions/checkout` and typical read-only repository access. No additional write scopes are required by the shown steps.

**Where to change:** `.github/workflows/playwright.yml`, between the `on:` triggers and `jobs:` (or at top-level before `jobs:`).  
**What to add:** a YAML top-level `permissions` mapping with `contents: read`.  
No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
